### PR TITLE
resolves issue that can cause application to crash if redis stopped/restarted/conn lost (fixes #4)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,10 +20,21 @@ exports.register = (server, options, next) => {
     internals.redis = new Redis(opts);
     server.app.redis = internals.redis;
 
+    let isFirstConnection = true;
+
     internals.redis.on('ready', () => {
 
         server.log(['info', 'hapi-ioredis'], 'connected to redis');
-        return next();
+
+        // If this is the first connection to Redis on Server start,
+        // wait until it's connected before continuing.
+
+        // $lab:coverage:off$
+        if (isFirstConnection) {
+            isFirstConnection = false;
+            return next();
+        }
+        // $lab:coverage:on$
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "ioredis"
   ],
   "author": "Gaston Festari <cilindrox@gmail.com>",
+  "contributors": [
+    {"name": "James Dixon", "email": "jim.w.dixon@gmail.com"}
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/cilindrox/hapi-ioredis.git"


### PR DESCRIPTION
Upon the connection to Redis being lost in one way or another (stopped, restart, etc), the plugin was calling `next()` in the function that listens for the `ready` event. This is fine for the initial connection to Redis when the server starts, but calling `next()` again at anytime will cause the server to reload, which can have ill effects (one of those described in #4 ). 

I added a simple flag to determine whether or not the `ready` event is being fired for the first time. If it is (such as on server start), the plugin will wait until the connection is established and then call `next()`. Otherwise, `next()` is never called again as the plugin has technically already been registered. This prevents the server from being reloaded if the `ready` event is fired again.

In addition, I also added some simple log messages to the other events supported by ioRedis in order to leave a more detailed trail of what's happening in the logs.

Let me know if you have any questions!

Cheers,
James