### PR TITLE
chore: bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   },
   "dependencies": {
     "hoek": "4.x.x",
-    "ioredis": "1.x.x"
+    "ioredis": "2.x.x"
   },
   "devDependencies": {
-    "code": "2.x.x",
-    "hapi": "13.x.x",
-    "lab": "10.x.x"
+    "code": "4.x.x",
+    "hapi": "16.x.x",
+    "lab": "11.x.x"
   },
   "main": "./lib/index.js",
   "license": "MIT"


### PR DESCRIPTION
Update ioredis to v2.x.x

See [this doc for breaking changes between v1 and v2](https://github.com/luin/ioredis/wiki/Breaking-changes-between-v1-and-v2)

Closes #6 