### PR TITLE
Support for multiple redis instances to be registered

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ var server = new Hapi.Server();
 server.connection({ host: 'localhost' });
 
 var options = {
-    // ioRedis config options 
+    // you can override the name of the instance (defaults to 'redis') available on server.app
+    // name: 'myRedisInstance'
+
+    // ioRedis config options
     // See: https://github.com/luin/ioredis/blob/master/API.md#new_Redis_new
 };
 
@@ -34,7 +37,7 @@ server.register({
 
     if (err) {
         console.error(err);
-    } 
+    }
     else {
         server.start(function () {
 
@@ -52,12 +55,12 @@ server.route( {
 
 // Access the ioRedis instance
 function usersHandler (request, reply) {
-  
+
     var client = request.redis;     // also available via request.server.app.redis
 
     // Do something with it
     client.hgetall('users', function (err, obj) {
-    
+
         if (err) {
             // handle error (https://github.com/luin/ioredis#error-handling)
         }
@@ -67,7 +70,7 @@ function usersHandler (request, reply) {
 };
 
 server.start(function() {
-    
+
     console.log("Server started at " + server.info.uri);
 });
 
@@ -89,7 +92,7 @@ This module borrows heavily from [hapi-redis], so kudos to @sandfox.
 [ioredis]: https://github.com/luin/ioredis
 [hapi-redis]: https://github.com/sandfox/node-hapi-redis
 
-## License 
+## License
 
 (The MIT License)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+
 'use strict';
 
 const Redis = require('ioredis');
@@ -16,9 +17,16 @@ exports.register = (server, options, next) => {
 
     Hoek.assert(opts, 'Invalid Redis URL settings provided.');
 
+    // Check to see if a Redis instance already exists at `server.app[name]`
+    const { name = 'redis' } = options;
+    const existingInstance = Hoek.reach(server, `app.${name}`);
+
+    Hoek.assert(!existingInstance, `Redis instance already exists at 'server.app.${name}'. Use the 'name' option to create a separate instance located at 'server.app.[name]'`);
+
+    // Create the Redis instance at `server.app.[name]`
     internals.redis = new Redis(opts);
-    server.app.redis = internals.redis;
-    server.decorate('request', 'redis', internals.redis);
+    server.app[name] = internals.redis;
+    server.decorate('request', name, internals.redis);
 
     let isFirstConnection = true;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ exports.register = (server, options, next) => {
     Hoek.assert(opts, 'Invalid Redis URL settings provided.');
 
     // Check to see if a Redis instance already exists at `server.app[name]`
-    const { name = 'redis' } = options;
+    const name = options.name || 'redis';
     const existingInstance = Hoek.reach(server, `app.${name}`);
 
     Hoek.assert(!existingInstance, `Redis instance already exists at 'server.app.${name}'. Use the 'name' option to create a separate instance located at 'server.app.[name]'`);

--- a/test/index.js
+++ b/test/index.js
@@ -96,3 +96,23 @@ it('decorates the request object with a redis prop', (done) => {
         });
     });
 });
+
+it('can override the name of the redis instance on server.app', (done) => {
+
+    const server = new Hapi.Server();
+    const plugin = {
+        register: IoRedis,
+        options: {
+            redis: { host: '127.0.0.1', port: '6379' },
+            name: 'myRedisInstance'
+        }
+    };
+
+    server.register(plugin, (err) => {
+
+        expect(err).to.not.exist();
+        expect(server.app.myRedisInstance).to.exist();
+        expect(server.app.myRedisInstance.disconnect).to.be.a.function();
+        done();
+    });
+});


### PR DESCRIPTION
This PR allows for multiple instances of Redis to be created and available under different keys on `request.server.app`. 

Note: I haven't added tests or updates to the README as I wanted to get your OK on the approach beforehand.